### PR TITLE
- Add ability to pass custom parameters to callback functions

### DIFF
--- a/src/components/lib/ListSelect.vue
+++ b/src/components/lib/ListSelect.vue
@@ -17,7 +17,7 @@
         },
         on: {
           select: this.onSelect,
-          searchchange: (searchText) => this.$emit('searchchange', searchText)
+          searchchange: (searchText) => this.$emit('searchchange', searchText, ...this.params)
         }
       })
     },
@@ -66,12 +66,12 @@
       },
       onSelect (option) {
         if (Object.keys(option).length === 0 && option.constructor === Object) {
-          this.$emit('select', option)
+          this.$emit('select', option, ...this.params)
         } else {
           const item = this.list.find((e, i) => {
             return e[this.optionValue] === option.value
           })
-          this.$emit('select', item)
+          this.$emit('select', item, ...this.params)
         }
       }
     },

--- a/src/components/lib/ModelListSelect.vue
+++ b/src/components/lib/ModelListSelect.vue
@@ -17,7 +17,7 @@
         },
         on: {
           input: this.onInput,
-          searchchange: (searchText) => this.$emit('searchchange', searchText)
+          searchchange: (searchText) => this.$emit('searchchange', searchText, ...this.params)
         }
       })
     },
@@ -73,14 +73,14 @@
       },
       onInput (option) {
         if (Object.keys(option).length === 0 && option.constructor === Object) {
-          this.$emit('input', option)
+          this.$emit('input', option, ...this.params)
         } else if (typeof option === 'object') {
           const item = this.list.find(e => {
             return e[this.optionValue] === option.value
           })
-          this.$emit('input', item)
+          this.$emit('input', item, ...this.params)
         } else if (typeof option === 'string') {
-          this.$emit('input', option)
+          this.$emit('input', option, ...this.params)
         }
       }
     },

--- a/src/components/lib/ModelSelect.vue
+++ b/src/components/lib/ModelSelect.vue
@@ -170,12 +170,12 @@
         this.searchText = ''
         this.closeOptions()
         if (typeof this.value === 'object' && this.value) {
-          this.$emit('input', option)
+          this.$emit('input', option, ...this.params)
         } else {
           if (option.value) {
-            this.$emit('input', option.value)
+            this.$emit('input', option.value, ...this.params)
           } else {
-            this.$emit('input', '')
+            this.$emit('input', '', ...this.params)
           }
         }
       }

--- a/src/components/lib/MultiListSelect.vue
+++ b/src/components/lib/MultiListSelect.vue
@@ -19,7 +19,7 @@
         },
         on: {
           select: this.onSelect,
-          searchchange: (searchText) => this.$emit('searchchange', searchText)
+          searchchange: (searchText) => this.$emit('searchchange', searchText, ...this.params)
         }
       })
     },
@@ -66,7 +66,7 @@
       },
       onSelect (options, option) {
         if (Object.keys(option).length === 0 && option.constructor === Object) {
-          this.$emit('select', options, option)
+          this.$emit('select', options, option, ...this.params)
         } else {
           const items = this.list.filter((e, i) => {
             return options.find((o, i) => {
@@ -74,7 +74,7 @@
             })
           })
           const item = find(this.list, [this.optionValue, option.value])
-          this.$emit('select', items, item)
+          this.$emit('select', items, item, ...this.params)
         }
       }
     },

--- a/src/components/lib/MultiSelect.vue
+++ b/src/components/lib/MultiSelect.vue
@@ -170,11 +170,11 @@
         const selectedOptions = unionWith(this.selectedOptions, [option], isEqual)
         this.closeOptions()
         this.searchText = ''
-        this.$emit('select', selectedOptions, option, 'insert')
+        this.$emit('select', selectedOptions, option, 'insert', ...this.params)
       },
       deleteItem (option) {
         const selectedOptions = reject(this.selectedOptions, option)
-        this.$emit('select', selectedOptions, option, 'delete')
+        this.$emit('select', selectedOptions, option, 'delete', ...this.params)
       },
       accentsTidy (s) {
         var r = s.toString().toLowerCase()

--- a/src/components/lib/mixins/commonMixin.js
+++ b/src/components/lib/mixins/commonMixin.js
@@ -24,6 +24,10 @@ export default {
       default: (text, inputText) => {
         return text.match(escapedRegExp(inputText))
       }
+    },
+    params: {
+      type: Array,
+      default: []
     }
   }
 }


### PR DESCRIPTION
Would like the ability to pass custom parameters to callback function so that we can share the same callback.

Eg.

```
                <model-select  :options="options"  @select="onSelect" :params="[1]">
                </model-select>
                <model-select  :options="options"  @select="onSelect" :params="[2]">
                </model-select>
```

```
        onSelect: function (item, id) {
            if (id == 1) {
                //do 1
            }
            else if (id == 2){
                //do 2
            }
        }
```

