### PR TITLE
Add slot for option in model-select

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules/
 test/unit/coverage
 test/e2e/reports
 dist
+.project
+.settings

--- a/src/App.vue
+++ b/src/App.vue
@@ -28,6 +28,7 @@
               <router-link :to="{ path: '/CustomFilter' }" class="item">Custom Filter</router-link>
               <router-link :to="{ path: '/List' }" class="item">List</router-link>
               <router-link :to="{ path: '/ListCustomText' }" class="item">List Custom Text</router-link>
+              <router-link :to="{ path: '/Slot' }" class="item">Slot</router-link>
             </div>
           </div>
         </div>
@@ -41,20 +42,20 @@
 
 <style src="semantic-ui-css/semantic.css"></style>
 <style>
-  .flexbox {
-    display: flex;
-  }
-  .flex-menu {
-    width: 250px;
-  }
-  .flex-content {
-    flex-grow: 1;
-  }
-  .flex-result {
-    min-width: 400px;
-    width: 400px;
-  }
-  .flexbox > * {
-    margin: 0 20px;
-  }
+.flexbox {
+  display: flex;
+}
+.flex-menu {
+  width: 250px;
+}
+.flex-content {
+  flex-grow: 1;
+}
+.flex-result {
+  min-width: 400px;
+  width: 400px;
+}
+.flexbox > * {
+  margin: 0 20px;
+}
 </style>

--- a/src/components/lib/ModelSelect.vue
+++ b/src/components/lib/ModelSelect.vue
@@ -22,7 +22,8 @@
            @keydown.delete="deleteTextOrItem"
     />
     <div class="text"
-         :class="textClass" :data-vss-custom-attr="searchTextCustomAttr">{{inputText}}
+         :class="textClass" :data-vss-custom-attr="searchTextCustomAttr">
+         {{inputText}}
     </div>
     <div class="menu"
          ref="menu"
@@ -37,7 +38,9 @@
              @click.stop="selectItem(option)"
              @mousedown="mousedownItem"
              @mouseenter="pointerSet(idx)">
-          {{option.text}}
+            <slot name="option" :value="option">
+                {{option.text}}
+            </slot>
         </div>
       </template>
     </div>

--- a/src/components/sample/Slot/Slot.vue
+++ b/src/components/sample/Slot/Slot.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    <h3>Slot</h3>
+    <slot-example />  
+  </div>
+</template>
+
+<script>
+import SlotExample from './_Slot'
+
+export default {
+  components: {
+    SlotExample
+  }
+}
+</script>

--- a/src/components/sample/Slot/_Slot.vue
+++ b/src/components/sample/Slot/_Slot.vue
@@ -1,0 +1,31 @@
+<template>
+    <div>
+        <model-select :options="options"
+                      placeholder="select item"
+                      v-model="item">
+            <template slot="option" slot-scope="option"> 
+                {{ option.value.text }} <span style="color:blue">HAVE VALUE: {{ option.value.value }} </span> 
+            </template>
+        </model-select>
+    </div>
+</template>
+
+<script>
+  import { ModelSelect } from '../../lib'
+
+  export default {
+    data () {
+      return {
+        item: { value: '', text: '' },
+        options: [
+          { value: '1', text: 'element 1' },
+          { value: '2', text: 'element 2' },
+          { value: '3', text: 'element 3' }
+        ]
+      }
+    },
+    components: {
+      ModelSelect
+    }
+  }
+</script>

--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,7 @@ import Basic from './components/sample/Basic/Basic'
 import CustomFilter from './components/sample/Basic/CustomFilter'
 import List from './components/sample/List/List'
 import ListCustomText from './components/sample/List/ListCustomText'
+import Slot from './components/sample/Slot/Slot'
 
 Vue.use(VueRouter)
 Vue.config.devtools = true
@@ -30,7 +31,9 @@ const routes = [
   { path: '/Basic', component: Basic },
   { path: '/CustomFilter', component: CustomFilter },
   { path: '/List', component: List },
-  { path: '/ListCustomText', component: ListCustomText }
+  { path: '/ListCustomText', component: ListCustomText },
+  { path: '/Slot', component: Slot }
+
 ]
 const router = new VueRouter({
   routes // short for routes: routes


### PR DESCRIPTION
With this feature, the options into a model-select can have custom template specified from the user using the slot, in order to add color to a specific part of the text or use all html needed in general. If no slot is specified from the user, the behavior is the existing.

Example:
```
<model-select :options="options" placeholder="select item" v-model="item">
   <template slot="option" slot-scope="option"> 
      {{ option.value.text }} <span style="color:blue">HAVE VALUE: {{ option.value.value }} </span> 
   </template>
</model-select>
```