### PR TITLE
BasicSelect filtered customAttrs fix

### DIFF
--- a/src/components/lib/BasicSelect.vue
+++ b/src/components/lib/BasicSelect.vue
@@ -95,8 +95,8 @@ export default {
     },
     customAttrs () {
       try {
-        if (Array.isArray(this.options)) {
-          return this.options.map(o => this.customAttr(o))
+        if (Array.isArray(this.filteredOptions)) {
+          return this.filteredOptions.map(o => this.customAttr(o))
         }
       } catch (e) {
         // if there is an error, just return an empty array


### PR DESCRIPTION
Resolves moreta/vue-search-select#117

Updating Basic Select to use filterOptions instead of options when checking customAttrs. This stops the issue where when searching, incorrect attrs get assigned based on the original options array, instead of the filteredOptions subset