### PR TITLE
#126 - Fix BasicSelect not working in IE11

### DIFF
--- a/src/lib/BasicSelect.vue
+++ b/src/lib/BasicSelect.vue
@@ -41,7 +41,7 @@
         v-for="(option, idx) in filteredOptions"
         :key="idx"
         class="item"
-        :class="{ 'selected': option.selected, 'selected': pointer === idx }"
+        :class="{ 'selected': option.selected || pointer === idx }"
         :data-vss-custom-attr="customAttrs[idx] ? customAttrs[idx] : ''"
         @click.stop="selectItem(option)"
         @mousedown="mousedownItem"


### PR DESCRIPTION
I got this error: Multiple definitions of a property not allowed in strict mode.