### PR TITLE
#126 - Fix MultiSelect not working in IE11

### DIFF
--- a/src/lib/MultiSelect.vue
+++ b/src/lib/MultiSelect.vue
@@ -52,7 +52,7 @@
         <div
           :key="idx"
           class="item"
-          :class="{ 'selected': option.selected, 'selected': pointer === idx }"
+          :class="{ 'selected': option.selected || pointer === idx }"
           :data-vss-custom-attr="customAttr(option)"
           @click.stop="selectItem(option)"
           @mousedown="mousedownItem"


### PR DESCRIPTION
I got this error: Multiple definitions of a property not allowed in strict mode.