### PR TITLE
Add slot to customize option labels as Vue

### DIFF
--- a/libs/components/ModelSelect.vue
+++ b/libs/components/ModelSelect.vue
@@ -48,7 +48,9 @@
         @mousedown="mousedownItem"
         @mouseenter="pointerSet(idx)"
       >
-        {{ option.text }}
+        <slot :option="option" :idx="idx">
+          {{ option.text }}
+        </slot>
       </div>
     </div>
   </div>

--- a/libs/components/MultiSelect.vue
+++ b/libs/components/MultiSelect.vue
@@ -14,7 +14,9 @@
         style="display: inline-block !important;"
         :data-vss-custom-attr="customAttr(option)"
       >
-        {{ option.text }}<i class="delete icon" @click="deleteItem(option)"></i>
+        <slot name="selected" :option="option" :idx="idx">
+          {{ option.text }}<i class="delete icon" @click="deleteItem(option)"></i>
+        </slot>
       </a>
     </template>
     <input
@@ -59,7 +61,9 @@
         @mousedown="mousedownItem"
         @mouseenter="pointerSet(idx)"
       >
-        {{ option.text }}
+        <slot :option="option" :idx="idx">
+          {{ option.text }}
+        </slot>
       </div>
     </div>
   </div>


### PR DESCRIPTION
I'd like to bring this change back to the forefront. This will allow users to customize the items:
```vue
<multi-select>
  <template #default="{ option, idx }">
    {{ idx }}: {{ option.text }}
  </template>
</multi-select>
```

Fixes #108 
Closes #109